### PR TITLE
Allow specifying the protocol ("http" or "https") to redirect to as the environment variable PROTOCOL

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM docker.io/library/nginx:1.27.0-alpine
 COPY default.conf.template /etc/nginx/templates/default.conf.template
 
 # Do not override this env var
-ENV NGINX_ENVSUBST_FILTER="LISTEN_PORT|PELICAN.*"
+ENV NGINX_ENVSUBST_FILTER="PROTOCOL|LISTEN_PORT|PELICAN.*"
 
 #
 # The following are meant to be overridden:
@@ -12,3 +12,4 @@ ENV NGINX_ENVSUBST_FILTER="LISTEN_PORT|PELICAN.*"
 ENV LISTEN_PORT=8000
 ENV PELICAN_CACHE_PORT=8443
 ENV PELICAN_SERVER_HOSTNAME=localhost
+ENV PROTOCOL=https

--- a/README.md
+++ b/README.md
@@ -25,3 +25,7 @@ The following environment variables are accepted:
     The port that incoming connections will arrive on.
     If not specified, this is `8000`.
 
+-   `PROTOCOL`:
+    The protocol (`http` or `https`), that the redirect
+    should use.  Defaults to `https`.
+

--- a/default.conf.template
+++ b/default.conf.template
@@ -1,5 +1,5 @@
 server {
     listen ${LISTEN_PORT};
-    return 301 https://${PELICAN_SERVER_HOSTNAME}:${PELICAN_CACHE_PORT}$request_uri;
+    return 301 ${PROTOCOL}://${PELICAN_SERVER_HOSTNAME}:${PELICAN_CACHE_PORT}$request_uri;
 }
 


### PR DESCRIPTION
Defaults to "https"; this used directly as the URL scheme.